### PR TITLE
Structure hash fixes

### DIFF
--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Literal, cast, get_args
 import numpy as np
 from monty.dev import deprecated
 from monty.io import zopen
-from monty.json import MSONable
+from monty.json import MSONable, jsanitize
 from numpy import cross, eye
 from numpy.linalg import norm
 from ruamel.yaml import YAML
@@ -3936,8 +3936,8 @@ class Structure(IStructure, collections.abc.MutableSequence):
         self._sites: list[PeriodicSite] = list(self._sites)  # type: ignore[assignment]
 
     def __hash__(self) -> int:
-        """Hash as_dict to account for mutability."""
-        return hash(json.dumps(self.as_dict()))
+        """Hash dict representation to account for mutability."""
+        return hash(json.dumps(jsanitize(self)))
 
     def __setitem__(
         self,

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -973,7 +973,7 @@ class TestStructure(PymatgenTest):
         assert struct.formula == "Li1 S2"
 
     def test_hashable(self):
-        assert isinstance(hash(self.struct),int)
+        assert isinstance(hash(self.struct), int)
 
     def test_sort(self):
         self.struct[0] = "F"

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -972,9 +972,8 @@ class TestStructure(PymatgenTest):
         struct[:2] = "S"
         assert struct.formula == "Li1 S2"
 
-    def test_not_hashable(self):
-        with pytest.raises(TypeError, match="unhashable type: 'Structure'"):
-            _ = {self.struct: 1}
+    def test_hashable(self):
+        assert isinstance(hash(self.struct),int)
 
     def test_sort(self):
         self.struct[0] = "F"


### PR DESCRIPTION
base structure hash on recursive `as_dict` (`jsanitize`) and change test in `tests/core/test_structure` to reflect that structure is now hashable