### PR TITLE
Fix garbage collection and cache sharing

### DIFF
--- a/src/pymatgen/analysis/structure_matcher.py
+++ b/src/pymatgen/analysis/structure_matcher.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.json import MSONable
 
-from pymatgen.core import SETTINGS, Composition, Lattice, Structure, get_el_sp, IStructure
+from pymatgen.core import SETTINGS, Composition, IStructure, Lattice, Structure, get_el_sp
 from pymatgen.optimization.linear_assignment import LinearAssignment
 from pymatgen.util.coord import lattice_points_in_supercell
 from pymatgen.util.coord_cython import is_coord_subset_pbc, pbc_shortest_vectors
@@ -953,13 +953,11 @@ class StructureMatcher(MSONable):
         if primitive_cell:
             reduced = reduced.get_primitive_structure()
         return reduced
-    
+
     @classmethod
     def _get_reduced_structure(cls, struct: Structure, primitive_cell: bool = True, niggli: bool = True) -> Structure:
         """Helper method to find a reduced structure."""
-        return Structure.from_sites(
-            cls._get_reduced_istructure(IStructure.from_sites(struct), primitive_cell, niggli)
-        )
+        return Structure.from_sites(cls._get_reduced_istructure(IStructure.from_sites(struct), primitive_cell, niggli))
 
     def get_rms_anonymous(self, struct1, struct2):
         """

--- a/src/pymatgen/core/structure.py
+++ b/src/pymatgen/core/structure.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Literal, cast, get_args
 import numpy as np
 from monty.dev import deprecated
 from monty.io import zopen
-from monty.json import MSONable, jsanitize
+from monty.json import MSONable
 from numpy import cross, eye
 from numpy.linalg import norm
 from ruamel.yaml import YAML
@@ -3867,6 +3867,8 @@ class IMolecule(SiteCollection, MSONable):
 class Structure(IStructure, collections.abc.MutableSequence):
     """Mutable version of structure."""
 
+    __hash__ = None  # type: ignore[assignment]
+
     def __init__(
         self,
         lattice: ArrayLike | Lattice,
@@ -3934,10 +3936,6 @@ class Structure(IStructure, collections.abc.MutableSequence):
         )
 
         self._sites: list[PeriodicSite] = list(self._sites)  # type: ignore[assignment]
-
-    def __hash__(self) -> int:
-        """Hash dict representation to account for mutability."""
-        return hash(json.dumps(jsanitize(self)))
 
     def __setitem__(
         self,

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -975,7 +975,7 @@ class TestStructure(PymatgenTest):
     def test_not_hashable(self):
         with pytest.raises(TypeError, match="unhashable type: 'Structure'"):
             _ = {self.struct: 1}
-            
+
     def test_sort(self):
         self.struct[0] = "F"
         returned = self.struct.sort()

--- a/tests/core/test_structure.py
+++ b/tests/core/test_structure.py
@@ -972,9 +972,10 @@ class TestStructure(PymatgenTest):
         struct[:2] = "S"
         assert struct.formula == "Li1 S2"
 
-    def test_hashable(self):
-        assert isinstance(hash(self.struct), int)
-
+    def test_not_hashable(self):
+        with pytest.raises(TypeError, match="unhashable type: 'Structure'"):
+            _ = {self.struct: 1}
+            
     def test_sort(self):
         self.struct[0] = "F"
         returned = self.struct.sort()

--- a/tests/electronic_structure/test_plotter.py
+++ b/tests/electronic_structure/test_plotter.py
@@ -153,7 +153,7 @@ class TestBSPlotter(PymatgenTest):
 
     def test_get_ticks(self):
         assert self.plotter.get_ticks()["label"][5] == "K", "wrong tick label"
-        assert self.plotter.get_ticks()["distance"][5] == 2.406607625322699, "wrong tick distance"
+        assert self.plotter.get_ticks()["distance"][5] == pytest.approx(2.406607625322699), "wrong tick distance"
 
     # Minimal baseline testing for get_plot. not a true test. Just checks that
     # it can actually execute.

--- a/tests/transformations/test_advanced_transformations.py
+++ b/tests/transformations/test_advanced_transformations.py
@@ -601,7 +601,7 @@ class TestDisorderedOrderedTransformation(PymatgenTest):
 @pytest.mark.skipif(not mcsqs_cmd, reason="mcsqs not present.")
 class TestSQSTransformation(PymatgenTest):
     def test_apply_transformation(self):
-        pzt_structs = loadfn(f"{TEST_FILES_DIR}/mcsqs/pzt-structs.json")
+        pzt_structs = loadfn(f"{TEST_FILES_DIR}/io/atat/mcsqs/pzt-structs.json")
         trans = SQSTransformation(scaling=[2, 1, 1], search_time=0.01, instances=1, wd=0)
         # nonsensical example just for testing purposes
         struct = self.get_structure("Pb2TiZrO6").copy()
@@ -612,7 +612,7 @@ class TestSQSTransformation(PymatgenTest):
 
     def test_return_ranked_list(self):
         # list of structures
-        pzt_structs_2 = loadfn(f"{TEST_FILES_DIR}/mcsqs/pzt-structs-2.json")
+        pzt_structs_2 = loadfn(f"{TEST_FILES_DIR}/io/atat/mcsqs/pzt-structs-2.json")
 
         n_structs_expected = 1
         sqs_kwargs = {"scaling": 2, "search_time": 0.01, "instances": 8, "wd": 0}


### PR DESCRIPTION
- Ensures that lru_cache is garbage collected by making the cached `_get_reduced_istructure` method a `staticmethod`
- Restores lack of hash for `Structure`
- Performs structure reduction on imutable `SiteOrderedIStructure` class
~- Clear `lru_cache` at `StructureMatcher` instantiation~
- Fixes a few extraneous tests (wrong path for `mcsqs` file, missing `pytest.approx` in `TestBSPlot`)